### PR TITLE
Relax the version check for rpm

### DIFF
--- a/newrelic-thinking-sphinx.gemspec
+++ b/newrelic-thinking-sphinx.gemspec
@@ -13,6 +13,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_rubygems_version = '>= 1.3.6'
 
-  spec.add_dependency 'newrelic_rpm', '~> 3.6.0'
+  spec.add_dependency 'newrelic_rpm', '~> 3.0'
   spec.add_dependency 'thinking-sphinx', '~> 3.0.0'
 end


### PR DESCRIPTION
Hi there - NewRelic 3.7 is out and appears to work fine with this.  How about relaxing the gemspec version check to `~> 3.0` rather than `~>3.6.0` ?
